### PR TITLE
Export LoRa Module Firmware Version via the AT Command Interface

### DIFF
--- a/include/at.h
+++ b/include/at.h
@@ -22,7 +22,8 @@
                          {"$RFQ", at_rfq, NULL, NULL, NULL, "Get RSSI/SNR of last RX packet"},\
                          {"$DEBUG", NULL, at_debug_set, NULL, NULL, "Show debug UART communication"},\
                          {"$REBOOT", at_reboot, NULL, NULL, NULL, "Firmware reboot"},\
-                         {"$FRESET", at_freset, NULL, NULL, NULL, "LoRa Module factory reset"}
+                         {"$FRESET", at_freset, NULL, NULL, NULL, "LoRa Module factory reset"},\
+                         {"$FVER", at_ver_read, NULL, NULL, NULL, "Show LoRa Module firmware version"}
 
 #define AT_LED_COMMANDS {"$BLINK", at_blink, NULL, NULL, NULL, "LED blink 3 times"},\
                         {"$LED", NULL, at_led_set, NULL, at_led_help, "LED on/off"}
@@ -67,6 +68,8 @@ bool at_repu_set(twr_atci_param_t *param);
 
 bool at_repc_read(void);
 bool at_repc_set(twr_atci_param_t *param);
+
+bool at_ver_read(void);
 
 bool at_reboot(void);
 bool at_freset(void);

--- a/include/at.h
+++ b/include/at.h
@@ -23,7 +23,7 @@
                          {"$DEBUG", NULL, at_debug_set, NULL, NULL, "Show debug UART communication"},\
                          {"$REBOOT", at_reboot, NULL, NULL, NULL, "Firmware reboot"},\
                          {"$FRESET", at_freset, NULL, NULL, NULL, "LoRa Module factory reset"},\
-                         {"$FVER", at_ver_read, NULL, NULL, NULL, "Show LoRa Module firmware version"}
+                         {"$FWVER", at_ver_read, NULL, NULL, NULL, "Show LoRa Module firmware version"}
 
 #define AT_LED_COMMANDS {"$BLINK", at_blink, NULL, NULL, NULL, "LED blink 3 times"},\
                         {"$LED", NULL, at_led_set, NULL, at_led_help, "LED on/off"}

--- a/src/at.c
+++ b/src/at.c
@@ -342,6 +342,15 @@ bool at_repc_set(twr_atci_param_t *param)
     return true;
 }
 
+bool at_ver_read(void)
+{
+    const char *version = twr_cmwx1zzabz_get_fw_version(_at.lora);
+
+    twr_atci_printfln("$VER: %s", version);
+
+    return true;
+}
+
 bool at_blink(void)
 {
     twr_led_blink(_at.led, 3);


### PR DESCRIPTION
This pull request adds the AT command AT$FVER which can be used to obtain the firmware version from LoRa Module.